### PR TITLE
Load vehicle details

### DIFF
--- a/bin/loadvehicles
+++ b/bin/loadvehicles
@@ -11,9 +11,13 @@ from cvts.models import Vehicle, VehicleType
 UNCLASSIFIED_STRING = 'Xe chưa phân loại'
 engine = create_engine(POSTGRES_CONNECTION_STRING)
 
+def make_type(dct):
+    dct['code'] = int(dct['code'])
+    return VehicleType(**dct)
+
 with open(os.path.join(CONFIG_PATH, 'vehicle-types.csv'), 'r') as vt:
     reader = csv.DictReader(vt)
-    vehicle_types = {r['type_vn']: VehicleType(**r) for r in reader}
+    vehicle_types = {r['type_vn']: make_type(r) for r in reader}
     
 vehicles = {}
 with open(os.path.join(CONFIG_PATH, 'vehicle-to-vehicle-type.csv'), 'r') as vtvt:

--- a/bin/loadvehicles
+++ b/bin/loadvehicles
@@ -1,0 +1,56 @@
+#!/usr/bin/env python
+
+import os
+import csv
+from pprint import pprint
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+from cvts.settings import POSTGRES_CONNECTION_STRING, CONFIG_PATH
+from cvts.models import Vehicle, VehicleType
+
+UNCLASSIFIED_STRING = 'Xe chưa phân loại'
+engine = create_engine(POSTGRES_CONNECTION_STRING)
+
+with open(os.path.join(CONFIG_PATH, 'vehicle-types.csv'), 'r') as vt:
+    reader = csv.DictReader(vt)
+    vehicle_types = {r['type_vn']: VehicleType(**r) for r in reader}
+    
+vehicles = {}
+with open(os.path.join(CONFIG_PATH, 'vehicle-to-vehicle-type.csv'), 'r') as vtvt:
+    reader = csv.DictReader(vtvt)
+    for i, row in enumerate(reader):
+        try:
+            vt = row.get('vehicle_type', None).strip()
+            rego = rego = row['vehicle_id_string'].strip()
+            if rego in vehicles:
+                if vehicles[rego] == UNCLASSIFIED_STRING:
+                    vehicles[rego] = vt
+                else:
+                    if vt != UNCLASSIFIED_STRING:
+                        raise Exception('duplicate vehicle types: "{}" and "{}"'.format(
+                            vt, vehicles[rego]))
+            else:
+                vehicles[rego] = vt
+
+        except Exception as e:
+            # TODO: warning to log
+            print('error at {}: {}'.format(i, e))
+            raise
+
+with Session(engine) as session, session.begin():
+    for v in vehicle_types.values():
+        session.add(v)
+
+    for i, (rego, vt) in enumerate(vehicles.items()):
+        try:
+            if vt is None or vt == '':
+                vehicle = Vehicle(rego=rego)
+            else:
+                vehicle = Vehicle(
+                    vehicle_type = vehicle_types[vt],
+                    rego = rego)
+            session.add(vehicle)
+        except Exception as e:
+            # TODO: warning to log
+            print('error at {}: '.format(i, e))
+            raise

--- a/cvts/models.py
+++ b/cvts/models.py
@@ -25,8 +25,10 @@ class VehicleType(DBase):
     """A list of vehicle types."""
     __tablename__ = 'vehicle_types'
     id            = Column(Integer, primary_key=True)
-    type_en       = Column(String, unique=True)
+    code          = Column(SmallInteger, unique=True)
     type_vn       = Column(String, unique=True)
+    type_en       = Column(String, unique=True)
+    group         = Column(String)
 
 class Base(DBase):
     """The location a vehicle is garraged."""

--- a/cvts/models.py
+++ b/cvts/models.py
@@ -77,5 +77,9 @@ class Traversal(DBase):
     trip          = relationship('Trip', backref='traversals')
     edge          = Column(BigInteger) # will be unsigned 64 bit int
     timestamp     = Column(Integer)
+    hour          = Column(SmallInteger)
+    DOW           = Column(SmallInteger)
+    DOY           = Column(SmallInteger)
+    WOY           = Column(SmallInteger)
     speed         = Column(Float)
     count         = Column(Float)

--- a/cvts/settings.py
+++ b/cvts/settings.py
@@ -71,11 +71,11 @@ DEBUG_DOC_LIMIT   = 10
 
 #: The minimum time a vehicle must not move for to be considered 'stopped' in
 #: seconds.
-MIN_STOP_TIME     = 20 * 60
+MIN_STOP_TIME     = 8 * 60
 
 #: The minimum speed a vehicle can be moving to be considered 'moving' in
 #: kilometers per hour.
-MIN_MOVING_SPEED  = 6
+MIN_MOVING_SPEED  = 4
 
 #: The minimum distance a vehicle can move between two (potentially non-adjacent)
 #: GPS points to not be considered 'moving' in meters.

--- a/cvts/tasks/_valhalla.py
+++ b/cvts/tasks/_valhalla.py
@@ -443,7 +443,7 @@ class MatchToNetwork(luigi.Task):
             list(tqdm(work, total=DEBUG_DOC_LIMIT))
         else:
             if RAW_DATA_FORMAT == RawDataFormat.GZIP:
-                input_files_gen = ((self.dates, (v,v)) for v in input_files.items())
+                input_files_gen = ((self.dates, (v,v)) for v in input_files)
             else:
                 input_files_gen = ((self.dates, v) for v in input_files.items())
 

--- a/cvts/tasks/_valhalla.py
+++ b/cvts/tasks/_valhalla.py
@@ -7,6 +7,7 @@ from glob import glob
 from multiprocessing import Pool
 from hashlib import sha256 as _hasher
 from functools import reduce
+from datetime import datetime
 import numpy as np
 import pandas as pd
 from sqlalchemy import create_engine
@@ -125,8 +126,6 @@ def write_to_db(vehicle, base, stops, trips, travs):
         for stop in stops: session.add(stop)
         for trip in trips: session.add(trip)
         for trav in travs: session.add(trav)
-
-
 
 def _get_vehicle(rego):
     with Session(_engine, expire_on_commit=False) as session, session.begin():
@@ -267,26 +266,44 @@ def _process_trips(rego, trips, seq_file_name, vehicle, base):
                     end     = stop2)
 
             def gen_traversals(result, trip, edge_ids):
+                def times(ts):
+                    d  = datetime.fromtimestamp(int(ts))
+                    _, week, day = d.isocalendar()
+                    week -= 1
+                    day  -= 1
+                    DOY = 7 * week + day
+                    return ts, d.hour, day, 7*week + day, week
+
                 missing_inds_and_ts, speeds =  _average_speed(rego, result)
                 if speeds is not None:
                     for index, line in speeds.iterrows():
+                        ts, hour, DOW, DOY, WOY = times(line['timestamp'])
                         yield Traversal(
-                            vehicle = vehicle,
-                            trip    = trip,
-                            edge    = line['edge_id'],
-                            timestamp = line['timestamp'],
-                            speed   = line['speed'],
-                            count   = line['weight'])
+                            vehicle   = vehicle,
+                            trip      = trip,
+                            edge      = line['edge_id'],
+                            timestamp = ts,
+                            hour      = hour,
+                            DOW       = DOW,
+                            DOY       = DOY,
+                            WOY       = WOY,
+                            speed     = line['speed'],
+                            count     = line['weight'])
 
                 if missing_inds_and_ts is not None:
                     for index, time in missing_inds_and_ts:
+                        ts, hour, DOW, DOY, WOY = times(time)
                         yield Traversal(
-                            vehicle = vehicle,
-                            trip    = trip,
-                            edge    = edge_ids[index],
-                            timestamp = time,
-                            speed   = None,
-                            count   = 1)
+                            vehicle   = vehicle,
+                            trip      = trip,
+                            edge      = edge_ids[index],
+                            timestamp = ts,
+                            hour      = hour,
+                            DOW       = DOW,
+                            DOY       = DOY,
+                            WOY       = WOY,
+                            speed     = None,
+                            count     = 1)
 
             results = [(run_trip(trip, ti), n_stationary) for \
                     ti, (n_stationary, trip) in enumerate(trips)]

--- a/cvts/tasks/_valhalla.py
+++ b/cvts/tasks/_valhalla.py
@@ -457,7 +457,7 @@ class MatchToNetwork(luigi.Task):
 
             work = map(lproc, input_files_subset)
             # wrap in list so we wait for jobby to finish.
-            list(tqdm(work, total=DEBUG_DOC_LIMIT))
+            list(tqdm(work, total=DEBUG_DOC_LIMIT, smoothing=1))
         else:
             if RAW_DATA_FORMAT == RawDataFormat.GZIP:
                 input_files_gen = ((self.dates, (v,v)) for v in input_files)
@@ -467,7 +467,7 @@ class MatchToNetwork(luigi.Task):
             with Pool(initializer = _init_db_connections) as workers:
                 work = workers.imap_unordered(lproc, input_files_gen)
                 # wrap in list so we wait for jobby to finish.
-                list(tqdm(work, total=len(input_files)))
+                list(tqdm(work, total=len(input_files), smoothing=1))
 
         # list the (seq) output files
         seq_output_files = glob(os.path.join(SEQ_PATH, '*'))


### PR DESCRIPTION
Load the vehicle ids and types into the DB and update the schema.

... a bug fix and some config twerks slip in here also.

## Loading the data

@pedrocamargo: Please check that *bin/loadvehicles* makes sense.

I noted there were rows in the data that contained no vehicle type. Is that expected?

As you noted, it would probably be easier to maintain a separate DB for the ETL. If/when we get more data or the data changes for any other reason, we'd need a file of the form:

```csv
vehicle_id_string,vehicle_type
bmYGZxu86kvN2kdkHOrQqw==,"Xe chưa phân loại"
bmYGZxu86kvN2kdkHOrQqw==,"Xe tuyến cố định"
3dfFMdloKKbqjXHjvyu43w==,"Xe chưa phân loại"
3dfFMdloKKbqjXHjvyu43w==,"Xe tải"
...
```

To load (column order does not matter).

## API

If you provide a function of the form:

```Python
def get_data_for_vehicle_id(
    vehicle_id_hash,
    dates: Iterable[date]) -> list[dict]
```

where `date` is a `datetime.date` and the resulting `dict`s are of the form we have been using to date, then we are done!


@adammckeown Adding you to make sure you're aware of the changes to the *traversals* table.