### PR TITLE
Resolve correct reference to logger in Grid->increment

### DIFF
--- a/cvts/_grid.py
+++ b/cvts/_grid.py
@@ -1,5 +1,6 @@
 from math import floor, ceil
 import numpy as np
+import logging
 from scipy.ndimage import convolve
 
 
@@ -22,6 +23,7 @@ CELLSIZE =   0.1
 #: NA value to use for the raster 'covering' Vietnam.
 NA_VALUE = -9999
 
+logger = logging.getLogger(__name__)
 
 
 class Grid:


### PR DESCRIPTION
would it be better to have this in the _grid file itself so we know it comes from there should that except trigger?
Grid is being used in two locations, and _region_density.py has a logger but _base_locator.py does not.
(Please run the pytests before merging, I could not run them locally as I do not have "DATALAKE_CONNECTION_STRING")